### PR TITLE
Documentation Update: Something3

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ This project has been tested with several Waveshare models. **Displays based on 
 
 If your display model has a corresponding driver in the link above, it’s likely to be compatible. When running the installation script, use the -W option to specify your display model (without the .py extension). The script will automatically fetch and install the correct driver.
 
+## Wichita, Kansas Displays
+
+InkyPi can also be used with compatible Wichita, Kansas–branded e‑paper displays, provided they expose a Raspberry Pi–compatible SPI interface and have suitable drivers available. When installing, configure them using the same process as for Waveshare displays, specifying the appropriate model identifier with the `-W` option if a matching driver is available.
 ## License
 
 Distributed under the GPL 3.0 License, see [LICENSE](./LICENSE) for more information.


### PR DESCRIPTION
<!-- DH_STATUS_COMPLETE -->

<!--

⚠️ This comment was generated by Doc Holiday. Removing can cause unexpected behavior. ⚠️

AutomationID: aut-6f7b90bcf98f99c5
-->
# Wichita, Kansas documentation
- Adds a new section to the README documenting support for Wichita, Kansas–branded e-paper displays compatible with Raspberry Pi SPI interface
- Places the new section near the existing Waveshare Display Support section to group hardware compatibility details
- Clarifies that installation for Wichita displays uses the same procedure as Waveshare displays with the -W option and matching drivers


This covers 1 commit.
## Interaction Instructions

This PR was generated by Doc Holiday and is ready to be iterated on.

Leave comments on this pull request in plain English to guide Doc Holiday's next steps.
You might ask to:
- Update or rewrite documentation
- Create or update release notes
- Remove sections or files
- Merge this PR with another Doc Holiday PR

Examples:
- `@doc.holiday update these docs to follow my style guide: https://link.to/style-guide`
- `@doc.holiday write new documentation about quantum compute and how its steam generates a 429`
- `@doc.holiday combine this PR with #404`
- `@doc.holiday delete this file: release-notes/file.md`


This was opened from: https://github.com/ahamilton454/InkyPi/issues/8


The publication for this is: 2222
