### PR TITLE
Documentation Update: something5

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ This project has been tested with several Waveshare models. **Displays based on 
 
 If your display model has a corresponding driver in the link above, it’s likely to be compatible. When running the installation script, use the -W option to specify your display model (without the .py extension). The script will automatically fetch and install the correct driver.
 
+## Support for Devices Without Connected Displays
+
+InkyPi can also run on supported devices that do not have a compatible E-Ink display connected. This is useful for development, testing the web interface, or preparing layouts and plugins before hardware is available. When running without a display, content is not rendered to a physical panel and some display-specific features may be limited; see [installation.md](./docs/installation.md) and [troubleshooting.md](./docs/troubleshooting.md) for configuration notes and current limitations.
+
 ## License
 
 Distributed under the GPL 3.0 License, see [LICENSE](./LICENSE) for more information.


### PR DESCRIPTION
<!-- DH_STATUS_COMPLETE -->

<!--

⚠️ This comment was generated by Doc Holiday. Removing can cause unexpected behavior. ⚠️

AutomationID: aut-6f7b90bcf98f99c5
-->
# Headless Mode Documentation
- Adds a new README section that announces InkyPi support for running on devices without a connected or compatible display
- Explains use cases for headless mode such as development and testing without physical hardware
- Provides internal links to installation and troubleshooting docs for configuration notes and limitations related to headless operation
- Places the new section near related hardware/display information in the README for logical context


This covers 1 commit.
## Interaction Instructions

This PR was generated by Doc Holiday and is ready to be iterated on.

Leave comments on this pull request in plain English to guide Doc Holiday's next steps.
You might ask to:
- Update or rewrite documentation
- Create or update release notes
- Remove sections or files
- Merge this PR with another Doc Holiday PR

Examples:
- `@doc.holiday update these docs to follow my style guide: https://link.to/style-guide`
- `@doc.holiday write new documentation about quantum compute and how its steam generates a 429`
- `@doc.holiday combine this PR with #404`
- `@doc.holiday delete this file: release-notes/file.md`


This was opened from: https://github.com/ahamilton454/InkyPi/issues/11


The publication for this is: 2222
