### PR TITLE
Documentation Update: something5

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ This project has been tested with several Waveshare models. **Displays based on 
 
 If your display model has a corresponding driver in the link above, it’s likely to be compatible. When running the installation script, use the -W option to specify your display model (without the .py extension). The script will automatically fetch and install the correct driver.
 
+
+## Other Display Types
+
+In addition to the Inky and Waveshare e-Paper displays listed above, InkyPi has experimental support for additional SPI-connected e-ink displays and controller boards.
+
+These alternate displays are supported through the same driver abstraction used for Waveshare devices. As long as a compatible Python driver is available for the target display and it exposes a similar framebuffer-style API, InkyPi can usually be adapted to drive it.
+
+Support for these non-similar / alternate displays is community-maintained and may require some manual configuration or small code changes. For guidance on extending display support, see [development.md](./docs/development.md) and [Building InkyPi Plugins](./docs/building_plugins.md).
+
 ## License
 
 Distributed under the GPL 3.0 License, see [LICENSE](./LICENSE) for more information.


### PR DESCRIPTION
<!-- DH_STATUS_COMPLETE -->

<!--

⚠️ This comment was generated by Doc Holiday. Removing can cause unexpected behavior. ⚠️

AutomationID: aut-6f7b90bcf98f99c5
-->
# Other Display Types documentation
- Adds a new section in the README documenting experimental support for additional SPI-connected e-ink displays and controller boards beyond Inky and Waveshare.
- Clarifies that support for these alternate displays is community-maintained and may require manual configuration.
- Links to developer documentation for guidance on extending display support and building custom plugins.
- Ensures that this new information is placed near the existing Waveshare Display Support section to maintain logical flow.


This covers 1 commit.
## Interaction Instructions

This PR was generated by Doc Holiday and is ready to be iterated on.

Leave comments on this pull request in plain English to guide Doc Holiday's next steps.
You might ask to:
- Update or rewrite documentation
- Create or update release notes
- Remove sections or files
- Merge this PR with another Doc Holiday PR

Examples:
- `@doc.holiday update these docs to follow my style guide: https://link.to/style-guide`
- `@doc.holiday write new documentation about quantum compute and how its steam generates a 429`
- `@doc.holiday combine this PR with #404`
- `@doc.holiday delete this file: release-notes/file.md`


This was opened from: https://github.com/ahamilton454/InkyPi/issues/11


The publication for this is: 2222
