### PR TITLE
Documentation Update: Somthing6

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,21 @@ Check out these similar projects:
 - [InkyCal](https://github.com/aceinnolab/Inkycal) - has modular plugins for building custom dashboards
 - [PiInk](https://github.com/tlstommy/PiInk) - inspiration behind InkyPi's flask web ui
 - [rpi_weather_display](https://github.com/sjnims/rpi_weather_display) - alternative eink weather dashboard with advanced power efficiency
+
+## Third-party plugins (CLI)
+
+InkyPi includes a plugin management CLI under the `inkypi` command.
+
+### Commands
+
+```bash
+inkypi plugin install <plugin_id> <git_repository_url>
+inkypi plugin uninstall <plugin_id>
+inkypi plugin list
+```
+
+### Notes
+
+- `inkypi plugin install` performs a shallow clone of the repository and expects a top-level folder that matches `<plugin_id>`.
+- `inkypi plugin uninstall` removes the plugin directory.
+- `inkypi plugin install` and `inkypi plugin uninstall` restart `inkypi.service`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ See [the wiki](https://github.com/fatihak/InkyPi/wiki) for a list of community-m
 **Disclosure:** The links above are affiliate links. I may earn a commission from qualifying purchases made through them, at no extra cost to you, which helps maintain and develop this project.
 
 ## Installation
-To install InkyPi, follow these steps:
+For end-to-end setup steps (including flashing Raspberry Pi OS), follow the detailed guide at [Detailed installation](./docs/installation.md).
+
+To install InkyPi from the repository, follow these steps:
 
 1. Clone the repository:
     ```bash
@@ -85,6 +87,16 @@ Note:
 - The installation process will automatically enable the required SPI and I2C interfaces on your Raspberry Pi.
 
 For more details, including instructions on how to image your microSD with Raspberry Pi OS, refer to [installation.md](./docs/installation.md). You can also checkout [this YouTube tutorial](https://youtu.be/L5PvQj1vfC4).
+
+### Service entrypoint
+
+The installer configures a systemd unit named `inkypi.service` that starts InkyPi via:
+
+```bash
+inkypi run
+```
+
+The `inkypi` entry script is installed at `/usr/local/bin/inkypi`.
 
 ## Update
 To update your InkyPi with the latest code changes, follow these steps:

--- a/README.md
+++ b/README.md
@@ -175,5 +175,5 @@ inkypi plugin list
 ### Notes
 
 - `inkypi plugin install` performs a shallow clone of the repository and expects a top-level folder that matches `<plugin_id>`.
-- `inkypi plugin uninstall` removes the plugin directory.
+- `inkypi plugin uninstall` removes the plugin directory at `src/plugins/<plugin_id>`.
 - `inkypi plugin install` and `inkypi plugin uninstall` restart `inkypi.service`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,6 +50,14 @@ sudo bash install/install.sh -W <waveshare_device_model>
 
 The installer downloads a matching driver file into `src/display/waveshare_epd/` using the model name (for example, `<waveshare_device_model>.py`) and also downloads `epdconfig.py` into the same directory.
 
+### Service entrypoint
+
+The installer configures a systemd unit named `inkypi.service`. The unit starts InkyPi via:
+
+```bash
+inkypi run
+```
+
 ## Updating InkyPi
 
 Use the update script to install system dependencies, upgrade Python packages in the existing virtual environment, refresh the `inkypi` executable, update JS/CSS vendor assets, and restart the systemd service.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,8 +60,6 @@ sudo bash install/update.sh
 
 The update script requires an existing virtual environment at `/usr/local/inkypi/venv_inkypi`.
 
-
-
 ### System services configured by the installer
 
 The installer configures these services:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,3 +31,40 @@
 </p>
 
 4. Click Yes to apply OS customization options and confirm
+
+## Installing InkyPi
+
+Run the installer from the repository root.
+
+```bash
+sudo bash install/install.sh
+```
+
+### Waveshare displays
+
+Waveshare installations use a display model identifier.
+
+```bash
+sudo bash install/install.sh -W <waveshare_device_model>
+```
+
+The installer downloads a matching driver file into `src/display/waveshare_epd/` using the model name (for example, `<waveshare_device_model>.py`) and also downloads `epdconfig.py` into the same directory.
+
+### System services configured by the installer
+
+The installer configures these services:
+
+- Enables SPI and I2C.
+- Installs and enables `earlyoom`.
+- On Raspberry Pi OS Bookworm (version `12`), installs and enables `zramswap` (via `zram-tools`) and writes `/etc/default/zramswap`.
+
+## Updating InkyPi
+
+Use the update script to install system dependencies, upgrade Python packages in the existing virtual environment, refresh the `inkypi` executable, update JS/CSS vendor assets, and restart the systemd service.
+
+```bash
+sudo bash install/update.sh
+```
+
+The update script requires an existing virtual environment at `/usr/local/inkypi/venv_inkypi`.
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,7 +62,7 @@ The update script requires an existing virtual environment at `/usr/local/inkypi
 
 ### System services configured by the installer
 
-The installer configures these services:
+The installer configures the following services to keep the device responsive and ready for long-running display workloads:
 
 - Enables SPI and I2C.
 - Installs and enables `earlyoom`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,14 +50,6 @@ sudo bash install/install.sh -W <waveshare_device_model>
 
 The installer downloads a matching driver file into `src/display/waveshare_epd/` using the model name (for example, `<waveshare_device_model>.py`) and also downloads `epdconfig.py` into the same directory.
 
-### System services configured by the installer
-
-The installer configures these services:
-
-- Enables SPI and I2C.
-- Installs and enables `earlyoom`.
-- On Raspberry Pi OS Bookworm (version `12`), installs and enables `zramswap` (via `zram-tools`) and writes `/etc/default/zramswap`.
-
 ## Updating InkyPi
 
 Use the update script to install system dependencies, upgrade Python packages in the existing virtual environment, refresh the `inkypi` executable, update JS/CSS vendor assets, and restart the systemd service.
@@ -68,3 +60,12 @@ sudo bash install/update.sh
 
 The update script requires an existing virtual environment at `/usr/local/inkypi/venv_inkypi`.
 
+
+
+### System services configured by the installer
+
+The installer configures these services:
+
+- Enables SPI and I2C.
+- Installs and enables `earlyoom`.
+- On Raspberry Pi OS Bookworm (version `12`), installs and enables `zramswap` (via `zram-tools`) and writes `/etc/default/zramswap`.


### PR DESCRIPTION
<!-- DH_STATUS_COMPLETE -->

<!--

⚠️ This comment was generated by Doc Holiday. Removing can cause unexpected behavior. ⚠️

AutomationID: aut-6f7b90bcf98f99c5
-->
# Installation documentation
- Adds a detailed installation guide covering flashing Raspberry Pi OS with customization options
- Documents running the InkyPi installer script and usage for Waveshare display models
- Describes system services configured by the installer including SPI, I2C, earlyoom, and zramswap
- Explains how to use the update script to refresh dependencies, virtual environment, and systemd service
- Moves the "System services configured by the installer" section from the middle to the end of the installation guide for improved logical flow
- Moves the system services section to the bottom of the installation guide to improve flow
- Revises the tone of the system services section to emphasize the importance of these services for device responsiveness and long-running display workloads
- Adds a new section to the README detailing the InkyPi plugin management CLI commands
- Documents commands for installing, uninstalling, and listing third-party plugins via the `inkypi` CLI
- Explains usage notes about shallow cloning for plugin install and service restart behavior after plugin changes
- Updates README to align uninstall command notes with plugin CLI behavior by specifying the plugin removal path
- Clarifies that plugin install and uninstall commands restart the inkypi.service to apply changes
- Updates installation instructions in README to include a link to a detailed installation guide covering Raspberry Pi OS flashing
- Adds information about the `inkypi.service` systemd service entrypoint and `inkypi run` command used by the service in the README installation section
- Adds a detailed markdown installation guide describing how to flash Raspberry Pi OS including customization of hostname, user, wireless, and SSH settings
- Clarifies running the installer script and usage for Waveshare displays with driver download details
- Documents that the installer configures the `inkypi.service` systemd unit that starts InkyPi via the `inkypi run` command
- Describes running the update script and its functions for system dependency refresh and restarting services
- Details the system services (SPI, I2C, earlyoom, zramswap) configured and enabled by the installer for system responsiveness


This covers 7 commits.
## Interaction Instructions

This PR was generated by Doc Holiday and is ready to be iterated on.

Leave comments on this pull request in plain English to guide Doc Holiday's next steps.
You might ask to:
- Update or rewrite documentation
- Create or update release notes
- Remove sections or files
- Merge this PR with another Doc Holiday PR

Examples:
- `@doc.holiday update these docs to follow my style guide: https://link.to/style-guide`
- `@doc.holiday write new documentation about quantum compute and how its steam generates a 429`
- `@doc.holiday combine this PR with #404`
- `@doc.holiday delete this file: release-notes/file.md`


This was opened from: https://github.com/ahamilton454/InkyPi/issues/17


The publication for this is: 2222
